### PR TITLE
feat(ansible): add Amazon Q Developer installation task

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -151,6 +151,10 @@
       tags:
         - zsh
 
+    - include_tasks: tasks/dev-pro.yml
+      tags:
+        - q
+
     - include_tasks: tasks/home.yml
       tags:
         - dotfiles

--- a/tasks/dev-pro.yml
+++ b/tasks/dev-pro.yml
@@ -1,0 +1,23 @@
+---
+- name: Download Amazon Q Developer
+  get_url:
+    url: 'https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q.deb'
+    dest: '/tmp/amazon-q.deb'
+    mode: '0644'
+  tags:
+    - q
+
+- name: Install Amazon Q Developer
+  become: true
+  apt:
+    deb: '/tmp/amazon-q.deb'
+    state: present
+  tags:
+    - q
+
+- name: Clean up package file
+  file:
+    path: '/tmp/amazon-q.deb'
+    state: absent
+  tags:
+    - q


### PR DESCRIPTION
Adds automated installation of Amazon Q Developer to the Ansible playbook for development machine setup.

## Changes

- **New task file**: tasks/dev-pro.yml - Downloads and installs Amazon Q Developer .deb package
- **Playbook integration**: Added include for dev-pro tasks with 'q' tag in main playbook
- **Dependencies**: Updated poetry.lock with cffi package version bump (1.16.0 → 1.17.1)

## Technical Details

The new task performs:
1. Downloads Amazon Q Developer .deb package from AWS release endpoint
2. Installs package using apt module with elevated privileges
3. Cleans up temporary package file
4. All tasks tagged with 'q' for selective execution

## Impact

• Enables automated setup of Amazon Q Developer on development machines
• Maintains consistency with existing task structure and tagging conventions
• No breaking changes to existing functionality