### PR TITLE
feat(ansible): add multi-platform sudo support and generic dev tools installer

### DIFF
--- a/files/ubuntu-stop-if-inactive.sh
+++ b/files/ubuntu-stop-if-inactive.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-SHUTDOWN_TIMEOUT=30
+SHUTDOWN_TIMEOUT=90
 if ! [[ $SHUTDOWN_TIMEOUT =~ ^[0-9]*$ ]]; then
     echo "shutdown timeout is invalid"
     exit 1

--- a/playbook.yml
+++ b/playbook.yml
@@ -65,9 +65,14 @@
         - dev
 
     - include_tasks: tasks/dev-tools.yml
+      vars:
+        dev_tools:
+          - { name: 'uv', url: 'https://astral.sh/uv/install.sh' }
+          - { name: 'pnpm', url: 'https://get.pnpm.io/install.sh' }
       tags:
-        - dev
+        - dev-tools
         - python
+        - node
 
     - name: Ensure pip_install_packages are installed.
       become_user: '{{ dev_user }}'

--- a/playbook.yml
+++ b/playbook.yml
@@ -64,6 +64,11 @@
       tags:
         - dev
 
+    - include_tasks: tasks/dev-tools.yml
+      tags:
+        - dev
+        - python
+
     - name: Ensure pip_install_packages are installed.
       become_user: '{{ dev_user }}'
       community.general.pipx:

--- a/playbook.yml
+++ b/playbook.yml
@@ -6,12 +6,12 @@
     - 'vars/{{ ansible_distribution | lower }}-vars.yml'
 
   tasks:
-    - name: Allow 'wheel' group to have passwordless sudo
+    - name: Allow wheel/sudo group to have passwordless sudo
       lineinfile:
         dest: /etc/sudoers
         state: present
-        regexp: '^%wheel'
-        line: '%wheel ALL=(ALL) NOPASSWD: ALL'
+        regexp: "^%{{ 'wheel' if ansible_os_family == 'RedHat' else 'sudo' }}"
+        line: "%{{ 'wheel' if ansible_os_family == 'RedHat' else 'sudo' }} ALL=(ALL) NOPASSWD: ALL"
         validate: 'visudo -cf %s'
       tags:
         - admin

--- a/tasks/dev-tools.yml
+++ b/tasks/dev-tools.yml
@@ -1,23 +1,34 @@
 ---
-- name: Check if uv is installed
+# Check if each development tool is already installed
+- name: Check if tool is installed
   become_user: '{{ dev_user }}'
-  shell: command -v uv
-  register: uv_check
+  shell: command -v {{ item.name }}
+  register: tool_check
   failed_when: false
   changed_when: false
+  loop: '{{ dev_tools }}'
+  tags:
+    - dev-tools
 
-- name: Download uv installer
+# Download installer scripts only for tools that aren't installed
+# Uses results from the previous check task
+- name: Download tool installer
   become_user: '{{ dev_user }}'
   get_url:
-    url: https://astral.sh/uv/install.sh
-    dest: /tmp/uv-install.sh
+    url: '{{ item.item.url }}'
+    dest: '/tmp/{{ item.item.name }}-install.sh'
     mode: '0755'
-  when: uv_check.rc != 0
-
-- name: Install uv
-  become_user: '{{ dev_user }}'
-  shell: /tmp/uv-install.sh
-  when: uv_check.rc != 0
+  when: item.rc != 0 # Only download if command -v failed (tool not found)
+  loop: '{{ tool_check.results }}'
   tags:
-    - dev
-    - python
+    - dev-tools
+
+# Execute installer scripts for tools that need to be installed
+# Uses the same results structure from the check task
+- name: Install tool
+  become_user: '{{ dev_user }}'
+  shell: '/tmp/{{ item.item.name }}-install.sh'
+  when: item.rc != 0 # Only install if command -v failed (tool not found)
+  loop: '{{ tool_check.results }}'
+  tags:
+    - dev-tools

--- a/tasks/dev-tools.yml
+++ b/tasks/dev-tools.yml
@@ -1,0 +1,23 @@
+---
+- name: Check if uv is installed
+  become_user: '{{ dev_user }}'
+  shell: command -v uv
+  register: uv_check
+  failed_when: false
+  changed_when: false
+
+- name: Download uv installer
+  become_user: '{{ dev_user }}'
+  get_url:
+    url: https://astral.sh/uv/install.sh
+    dest: /tmp/uv-install.sh
+    mode: '0755'
+  when: uv_check.rc != 0
+
+- name: Install uv
+  become_user: '{{ dev_user }}'
+  shell: /tmp/uv-install.sh
+  when: uv_check.rc != 0
+  tags:
+    - dev
+    - python


### PR DESCRIPTION
Enhanced the Ansible playbook with cross-platform compatibility for sudo configuration and added a reusable development tools installation system. Also increased shutdown timeout for better development workflow.

## Changes
- Fixed sudo group configuration to work on both Red Hat (wheel) and Debian (sudo) systems
- Created generic dev-tools task for installing tools via downloadable scripts
- Increased shutdown timeout from 30 to 90 minutes
- Added uv and pnpm installation support

## New Features
- **Multi-platform sudo support**: Automatically detects OS family and configures appropriate admin group with passwordless sudo
- **Generic dev tools installer**: Reusable task system that checks for tool existence, downloads installers only when needed
- **uv and pnpm installation**: Added Python uv and Node.js pnpm package managers

## Technical Details
- Used Ansible conditional templating to dynamically select correct sudo group based on ansible_os_family
- Implemented idempotent tool installation using command -v checks and conditional execution
- Created parameterized task structure allowing tool definitions to be passed from main playbook
