### PR TITLE
feat: Ubuntu-first tooling updates, add CLAUDE.md, and claude-code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is an Ansible playbook project that provisions a cloud EC2 instance as a fully configured development machine. It is used as a submodule of `dev-environment-wizard` and is meant to be run from a local machine against a remote host over SSH.
+
+## Commands
+
+```bash
+# Install Python/Ansible dependencies (first time only)
+uv sync
+
+# Install Ansible Galaxy roles and collections (first time, or after requirements.yml changes)
+uv run ansible-galaxy install -r requirements.yml --force
+
+# Run the full playbook against a target machine
+uv run ansible-playbook playbook.yml -i <HOST_IP_OR_INSTANCE_ID>, -u <USER>
+
+# Use the convenience wrapper script (sets user from $dev_user env var, defaults to ec2-user)
+./scripts/machine-setup.sh <machine_name> [extra ansible-playbook args...]
+# Example:
+./scripts/machine-setup.sh i-0abc123 -e dev_user=dev -u ubuntu
+
+# Run only specific tagged tasks
+uv run ansible-playbook playbook.yml -i <HOST>, --tags "packages,docker"
+```
+
+**Note:** The trailing comma after the host address is required when passing a single host inline (e.g., `-i 192.168.1.1,`).
+
+## Architecture
+
+### Execution flow
+
+`playbook.yml` is the single entry point. It runs as `root` (`become: yes`) and:
+
+1. Loads `vars/defaults.yml` (shared defaults for all distros)
+2. Conditionally loads `vars/<ansible_distribution|lower>-vars.yml` (e.g., `amazon-vars.yml` or `ubuntu-vars.yml`) to set OS-specific package lists and the default `user` variable
+3. Runs tasks inline and delegates to task files in `tasks/`
+
+### Variable precedence
+
+- `vars/defaults.yml` — shared defaults: dotfiles repo URL, Node.js version, npm config, `node_packages`, `backup_files`
+- `vars/amazon-vars.yml` — sets `user: ec2-user`, Amazon Linux package list
+- `vars/ubuntu-vars.yml` — sets `user: ubuntu`, Ubuntu/Debian package list
+- `dev_user` — the non-root user to configure; defaults to the distro `user` value; can be overridden via `-e dev_user=<name>`
+
+### Task files and their tags
+
+| File | Tags | Purpose |
+|------|------|---------|
+| `tasks/user.yml` | `user` | Creates `dev_user` group/user, adds to `sudo`/`wheel` |
+| `tasks/awscli-2.yml` | *(inline)* | Installs AWS CLI v2 |
+| `tasks/dev-tools.yml` | `dev-tools`, `python`, `node` | Installs `uv` and `pnpm` via install scripts |
+| `tasks/vim.yml` | `vim`, `dev` | Builds vim from source |
+| `tasks/dev-pro.yml` | `q` | Installs `q` (AWS CLI query tool) |
+| `tasks/home.yml` | `dotfiles`, `backup`, `home_env`, `ssh` | Installs pyenv, clones dotfiles repo, creates symlinks, sets up SSH |
+| `tasks/auto-shutdown.yml` | `shutdown` | Installs OS-specific inactivity shutdown script as a systemd timer |
+
+### Notable behaviors
+
+- **Dotfiles**: `tasks/home.yml` clones `https://github.com/abest0/dotfiles` into `~/dotfiles`, backs up existing dotfiles to `~/backup_dotfiles/`, then symlinks them from `~/dotfiles/<name>` to `~/.<name>` for each item in `backup_files`.
+- **Auto-shutdown**: Copies `files/amazon-stop-if-inactive.sh` or `files/ubuntu-stop-if-inactive.sh` based on `ansible_distribution`, sets up a systemd timer (enabled) and service (disabled by default).
+- **Node.js**: Uses `geerlingguy.nodejs` role for non-Amazon Linux 2023; uses direct `npm` module for Amazon Linux 2023 (version `"2023"`).
+- **Docker**: Installed via a custom role at `git+https://github.com/abest0/ansible-role-docker.git`; `dev_user` is added to the docker group.
+
+### Galaxy dependencies (`requirements.yml`)
+
+- `geerlingguy.repo-epel` (1.3.0) — EPEL repo for RedHat-family
+- `geerlingguy.nodejs` — Node.js installation
+- `abest0/ansible-role-docker` — Docker installation (from GitHub)
+- `amazon.aws` collection

--- a/files/install-tmux.sh
+++ b/files/install-tmux.sh
@@ -1,21 +1,21 @@
-# Install tmux on rhel/centos 7
+# Install tmux from source (for distros where the package manager has an outdated version)
 
 # install deps
 yum install -yy gcc kernel-devel make ncurses-devel
 
 # DOWNLOAD SOURCES FOR LIBEVENT AND MAKE AND INSTALL
-curl -OL https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz
-tar -xvzf libevent-2.1.8-stable.tar.gz
-cd libevent-2.1.8-stable
+curl -OL https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
+tar -xvzf libevent-2.1.12-stable.tar.gz
+cd libevent-2.1.12-stable
 ./configure --prefix=/usr/local
 make
 sudo make install
 cd ..
 
 # DOWNLOAD SOURCES FOR TMUX AND MAKE AND INSTALL
-curl -OL https://github.com/tmux/tmux/releases/download/2.7/tmux-2.7.tar.gz
-tar -xvzf tmux-2.7.tar.gz
-cd tmux-2.7
+curl -OL https://github.com/tmux/tmux/releases/download/3.5a/tmux-3.5a.tar.gz
+tar -xvzf tmux-3.5a.tar.gz
+cd tmux-3.5a
 LDFLAGS="-L/usr/local/lib -Wl,-rpath=/usr/local/lib" ./configure --prefix=/usr/local
 make
 sudo make install

--- a/playbook.yml
+++ b/playbook.yml
@@ -183,13 +183,10 @@
         - zsh
 
     - include_tasks: tasks/vim.yml
+      when: ansible_os_family == 'RedHat'
       tags:
         - vim
         - dev
-
-    - include_tasks: tasks/dev-pro.yml
-      tags:
-        - q
 
     - include_tasks: tasks/home.yml
       tags:

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -18,3 +18,4 @@ backup_files:
 node_packages:
   - aws-cdk
   - typescript
+  - name: '@anthropic-ai/claude-code'


### PR DESCRIPTION
 ## Overview

  Improves the playbook for Ubuntu-first usage, updates tooling to current versions,
  adds repo documentation, and removes a deprecated dependency.

  ## Commits

  - `aba5799` docs: add CLAUDE.md with architecture and usage guidance
  - `68c775f` feat: update tooling, skip vim build on Ubuntu, add claude-code

  ## Changes

  - **vim**: skip build-from-source on Ubuntu (guarded to RedHat only); Ubuntu gets vim via apt
  - **tmux**: bump libevent 2.1.8 → 2.1.12-stable and tmux 2.7 → 3.5a
  - **claude-code**: add `@anthropic-ai/claude-code` to node_packages for global npm install
  - **dev-pro**: remove tasks/dev-pro.yml (Amazon Q / Kiro precursor) from playbook
  - **docs**: add CLAUDE.md covering commands, playbook flow, variable precedence, and task reference